### PR TITLE
Minimum configurable CORS support

### DIFF
--- a/src/main/java/org/gaul/s3proxy/AwsSignature.java
+++ b/src/main/java/org/gaul/s3proxy/AwsSignature.java
@@ -284,12 +284,14 @@ final class AwsSignature {
         /*
         CORS Preflight
 
-        The signature is based on the canonical request, which includes the HTTP Method
+        The signature is based on the canonical request, which includes the HTTP
+        Method.
         For presigned URLs, the method must be replaced with OPTIONS to match
         */
         String method = request.getMethod();
         if ("OPTIONS".equals(method)) {
-          String corsMethod = request.getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+          String corsMethod = request.getHeader(
+                  HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
           if (corsMethod != null) {
             method = corsMethod;
           }

--- a/src/main/java/org/gaul/s3proxy/CORSRules.java
+++ b/src/main/java/org/gaul/s3proxy/CORSRules.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class CORSRules {
+    private String allowedMethodsRaw;
+    private String allowedHeadersRaw;
+    private List<Pattern> allowedOrigins;
+    private List<String> allowedMethods;
+    private List<String> allowedHeaders;
+
+    private static final String VALUE_SEPARATOR = " ";
+    private static final String HEADER_VALUE_SEPARATOR = ", ";
+    private static final String ALLOW_ANY_HEADER = "*";
+
+    private static final Logger logger = LoggerFactory.getLogger(
+            CORSRules.class);
+
+    protected CORSRules() {
+        // CORS Allow all
+        this(".+", "GET PUT POST", ALLOW_ANY_HEADER);
+    }
+
+    protected CORSRules(String allowedOrigins, String allowedMethods,
+            String allowedHeaders) {
+        this.allowedOrigins = new ArrayList<Pattern>();
+        for (String origin: allowedOrigins.split(VALUE_SEPARATOR)) {
+            this.allowedOrigins.add(
+                    Pattern.compile(origin, Pattern.CASE_INSENSITIVE));
+        }
+        this.allowedMethods = Arrays.asList(allowedMethods.split(
+                VALUE_SEPARATOR));
+        this.allowedHeaders = Arrays.asList(allowedHeaders.split(
+                VALUE_SEPARATOR));
+
+        this.allowedMethodsRaw = Joiner.on(HEADER_VALUE_SEPARATOR).join(
+                this.allowedMethods);
+        this.allowedHeadersRaw = allowedHeaders;
+    }
+
+    public String getAllowedMethods() {
+       return this.allowedMethodsRaw;
+    }
+
+    public boolean isOriginAllowed(String origin) {
+        if (!Strings.isNullOrEmpty(origin)) {
+            for (Pattern pattern: this.allowedOrigins) {
+                Matcher matcher = pattern.matcher(origin);
+                if (matcher.matches()) {
+                    logger.debug("CORS origin allowed: {}", origin);
+                    return true;
+                }
+            }
+        }
+        logger.debug("CORS origin not allowed: {}", origin);
+        return false;
+    }
+
+    public boolean isMethodAllowed(String method) {
+        if (!Strings.isNullOrEmpty(method)) {
+            if (this.allowedMethods.contains(method)) {
+                logger.debug("CORS method allowed: {}", method);
+                return true;
+            }
+        }
+        logger.debug("CORS method not allowed: {}", method);
+        return false;
+    }
+
+    public boolean isEveryHeaderAllowed(String headers) {
+        if (!this.allowedHeadersRaw.equals(ALLOW_ANY_HEADER)) {
+            for (String header: headers.split(HEADER_VALUE_SEPARATOR)) {
+                if (!this.allowedHeaders.contains(header)) {
+                    logger.debug("CORS headers not allowed: {}", headers);
+                    return false;
+                }
+            }
+        }
+        logger.debug("CORS headers allowed: {}", headers);
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        CORSRules that = (CORSRules) object;
+        return this.allowedOrigins.equals(that.allowedOrigins) &&
+                this.allowedMethodsRaw.equals(that.allowedMethodsRaw) &&
+                this.allowedHeadersRaw.equals(that.allowedHeadersRaw);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.allowedOrigins.hashCode(),
+                this.allowedMethodsRaw, this.allowedHeadersRaw);
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -32,6 +32,12 @@ public final class S3ProxyConstants {
     /** When true, include "Access-Control-Allow-Origin: *" in all responses. */
     public static final String PROPERTY_CORS_ALLOW_ALL =
             "s3proxy.cors-allow-all";
+    public static final String PROPERTY_CORS_ALLOW_ORIGINS =
+            "s3proxy.cors-allow-origins";
+    public static final String PROPERTY_CORS_ALLOW_METHODS =
+            "s3proxy.cors-allow-methods";
+    public static final String PROPERTY_CORS_ALLOW_HEADERS =
+            "s3proxy.cors-allow-headers";
     public static final String PROPERTY_CREDENTIAL =
             "s3proxy.credential";
     public static final String PROPERTY_IGNORE_UNKNOWN_HEADERS =

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
@@ -44,10 +44,10 @@ final class S3ProxyHandlerJetty extends AbstractHandler {
             AuthenticationType authenticationType, final String identity,
             final String credential, @Nullable String virtualHost,
             long v4MaxNonChunkedRequestSize, boolean ignoreUnknownHeaders,
-            boolean corsAllowAll, String servicePath) {
+            CORSRules corsRules, String servicePath) {
         handler = new S3ProxyHandler(blobStore, authenticationType, identity,
                 credential, virtualHost, v4MaxNonChunkedRequestSize,
-                ignoreUnknownHeaders, corsAllowAll, servicePath);
+                ignoreUnknownHeaders, corsRules, servicePath);
     }
 
     private void sendS3Exception(HttpServletRequest request,

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -8,6 +8,9 @@ exec java \
     -Ds3proxy.identity=${S3PROXY_IDENTITY} \
     -Ds3proxy.credential=${S3PROXY_CREDENTIAL} \
     -Ds3proxy.cors-allow-all=${S3PROXY_CORS_ALLOW_ALL} \
+    -Ds3proxy.cors-allow-origins="${S3PROXY_CORS_ALLOW_ORIGINS}" \
+    -Ds3proxy.cors-allow-methods="${S3PROXY_CORS_ALLOW_METHODS}" \
+    -Ds3proxy.cors-allow-headers="${S3PROXY_CORS_ALLOW_HEADERS}" \
     -Ds3proxy.ignore-unknown-headers=${S3PROXY_IGNORE_UNKNOWN_HEADERS} \
     -Djclouds.provider=${JCLOUDS_PROVIDER} \
     -Djclouds.identity=${JCLOUDS_IDENTITY} \


### PR DESCRIPTION
* Allows specifying allowed Origins, Methods and Headers for CORS Preflight requests. 
* Adding `Origin` header in CORS actual requests for GET, POST and PUT.

Allowed settings with regex looks like:
```
docker run --rm -t -i --publish 8888:80 \
   -e LOG_LEVEL="debug" \
   -e S3PROXY_... \
   -e S3PROXY_CORS_ALLOW_ORIGINS="https://.+\.example\.com https://.+\.example\.cloud http://localhost:.+" \
   -e S3PROXY_CORS_ALLOW_METHODS="GET PUT" \
   -e S3PROXY_CORS_ALLOW_HEADERS="Content-Type Accept" \
   -e JCLOUDS_... \
   --name s3proxy reimannf/s3proxy:latest
```

`S3PROXY_CORS_ALLOW_ALL` still works as expected.
This does not add support for S3 CORS bucket operations as such.